### PR TITLE
fix bug in fps field

### DIFF
--- a/vimeo/videos.go
+++ b/vimeo/videos.go
@@ -43,6 +43,22 @@ type File struct {
 	MD5         string    `json:"md5,omitempty"`
 }
 
+// Download internal object provides access to video information for download
+type Download struct {
+	Quality     string    `json:"quality"`
+	Type        string    `json:"type"`
+	Width       int       `json:"width"`
+	Height      int       `json:"height"`
+	Expires     time.Time `json:"expires"`
+	Link        string    `json:"link"`
+	CreatedTime time.Time `json:"created_time"`
+	Fps         int       `json:"fps"`
+	Size        int       `json:"size"`
+	Md5         string    `json:"md5"`
+	PublicName  string    `json:"public_name"`
+	SizeShort   string    `json:"size_short"`
+}
+
 // App internal object provides access to specific app.
 type App struct {
 	URI  string `json:"uri,omitempty"`
@@ -138,6 +154,7 @@ type Video struct {
 	Categories    []*Category   `json:"categories,omitempty"`
 	User          *User         `json:"user,omitempty"`
 	Files         []*File       `json:"files,omitempty"`
+	Download      []*Download   `json:"download,omitempty"`
 	App           *App          `json:"app,omitempty"`
 	Status        string        `json:"status,omitempty"`
 	ResourceKey   string        `json:"resource_key,omitempty"`

--- a/vimeo/videos.go
+++ b/vimeo/videos.go
@@ -52,7 +52,7 @@ type Download struct {
 	Expires     time.Time `json:"expires"`
 	Link        string    `json:"link"`
 	CreatedTime time.Time `json:"created_time"`
-	Fps         int       `json:"fps"`
+	Fps         float64   `json:"fps"`
 	Size        int       `json:"size"`
 	Md5         string    `json:"md5"`
 	PublicName  string    `json:"public_name"`


### PR DESCRIPTION
fix bug, fps can be float, example:

```        
        {
            "quality": "hd",
            "type": "video/mp4",
            "width": 1920,
            "height": 1080,
            "link": "https://player.vimeo.com/external/5",
            "created_time": "2021-05-27T18:55:05+00:00",
            "fps": 29.97,
            "size": 9386625,
            "md5": "2b3d50bdff418e245aeb37ae93ab2ea4",
            "public_name": "HD 1080p",
            "size_short": "8.95MB"
        }
```