### PR TITLE
Adding video_file_id to File type

### DIFF
--- a/vimeo/videos.go
+++ b/vimeo/videos.go
@@ -32,6 +32,7 @@ type Stats struct {
 
 // File internal object provides access to video file information
 type File struct {
+	FileID      string    `json:"video_file_id,omitempty"`
 	Quality     string    `json:"quality,omitempty"`
 	Type        string    `json:"type,omitempty"`
 	Width       int       `json:"width,omitempty"`


### PR DESCRIPTION
In order to map these to a unique database row, I'd like to have access to the `video_file_id` field.